### PR TITLE
Re-trigger release build (Java 25 / Camunda 7.24)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <!-- Java 25 / WildFly 40 / Camunda 7.24 (25.104.x) upgrade — release-build trigger; no functional change. -->
     <parent>
         <groupId>uk.gov.moj.cpp.common</groupId>
         <artifactId>service-parent-pom</artifactId>


### PR DESCRIPTION
Adds an inert comment to the root pom so merging produces a real file change — the previous empty trigger PR merged without firing the release build (Azure path filter skips no-op merges). No functional change; will be squashed into the Java 25 upgrade on the eventual merge to main.