### PR TITLE
Re-trigger 25.104.x release build (chart historyTimeToLive republish)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <!-- Java 25 / WildFly 40 / Camunda 7.24 (25.104.x) upgrade — release-build trigger; no functional change. -->
+    <!-- Java 25 / WildFly 40 / Camunda 7.24 (25.104.x) upgrade — release-build re-trigger after the wildfly-app chart was republished with the global Camunda historyTimeToLive (P180D) default; no functional change. -->
     <parent>
         <groupId>uk.gov.moj.cpp.common</groupId>
         <artifactId>service-parent-pom</artifactId>


### PR DESCRIPTION
Re-trigger the IndividualCI release/validation build for the Java 25 / WildFly 40 / Camunda 7.24 (25.104.x) upgrade.

**Why:** the deployed `wildfly-app` chart tag `0.25.3-wildfly40` has been republished to include the global Camunda engine `historyTimeToLive` (P180D) default. The earlier release builds deployed against the pre-fix chart and failed at process registration (ENGINE-12018 — no process deployed). Merging this re-fires the deploy + integration tests against the corrected chart.

**Change:** inert pom comment only — no functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)