### PR TITLE
Re-trigger 25.104.x release build (depends on shared workmanagement 7.24 schema)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <!-- Java 25 / WildFly 40 / Camunda 7.24 (25.104.x) upgrade — release-build re-trigger after the wildfly-app chart was republished with the global Camunda historyTimeToLive (P180D) default; no functional change. -->
+    <!-- Java 25 / WildFly 40 / Camunda 7.24 (25.104.x) upgrade — release-build re-trigger once the shared workmanagement Camunda DB is on the 7.24 schema (camunda-liquibase 25.104.0-M1, built by boxworkmanagement/workmanagementproxy). businessprocesses has no camunda-liquibase of its own. No functional change. -->
     <parent>
         <groupId>uk.gov.moj.cpp.common</groupId>
         <artifactId>service-parent-pom</artifactId>


### PR DESCRIPTION
**Re-trigger only — no in-repo fix exists for businessprocesses.**

businessprocesses uses the shared **workmanagement** Camunda engine DB but does **not** run camunda-liquibase itself (its `docker/scripts/liquibase.sh` builds only eventstore/viewstore/system). Its release-build ITs (e.g. `SJPTriggersDeleteDocumentsTest` — delete-financial-means timer never fires) fail while that shared DB is on the **Camunda 7.17** schema.

**Dependency / ordering:** merge **after** the shared `workmanagement` DB is migrated to **7.24**, i.e. after boxworkmanagement (#14) and work-management-proxy (#17) — which bump `camunda-liquibase` to `25.104.0-M1` — and/or after the `workmanagement` dbsetup image is bumped off `17.21.2` in cpp-aks-deploy `validation25.env`. Merging this before then will just fail again.

Inert pom comment only; no functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)