### PR TITLE
Bump service-parent-pom M4 -> M7 (version 25.104.0-M3-SNAPSHOT)

### DIFF
--- a/businessprocesses-command/businessprocesses-command-handler/pom.xml
+++ b/businessprocesses-command/businessprocesses-command-handler/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>businessprocesses-command</artifactId>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
-        <version>25.104.1-M2-SNAPSHOT</version>
+        <version>25.104.0-M3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/businessprocesses-command/pom.xml
+++ b/businessprocesses-command/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
         <artifactId>businessprocesses-parent</artifactId>
-        <version>25.104.1-M2-SNAPSHOT</version>
+        <version>25.104.0-M3-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/businessprocesses-domain/businessprocesses-domain-aggregate/pom.xml
+++ b/businessprocesses-domain/businessprocesses-domain-aggregate/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>businessprocesses-domain</artifactId>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
-        <version>25.104.1-M2-SNAPSHOT</version>
+        <version>25.104.0-M3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/businessprocesses-domain/businessprocesses-domain-events/pom.xml
+++ b/businessprocesses-domain/businessprocesses-domain-events/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>businessprocesses-domain</artifactId>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
-        <version>25.104.1-M2-SNAPSHOT</version>
+        <version>25.104.0-M3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/businessprocesses-domain/pom.xml
+++ b/businessprocesses-domain/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>businessprocesses-parent</artifactId>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
-        <version>25.104.1-M2-SNAPSHOT</version>
+        <version>25.104.0-M3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/businessprocesses-event-sources/pom.xml
+++ b/businessprocesses-event-sources/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>businessprocesses-parent</artifactId>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
-        <version>25.104.1-M2-SNAPSHOT</version>
+        <version>25.104.0-M3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/businessprocesses-event/businessprocesses-event-domain/pom.xml
+++ b/businessprocesses-event/businessprocesses-event-domain/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>businessprocesses-event</artifactId>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
-        <version>25.104.1-M2-SNAPSHOT</version>
+        <version>25.104.0-M3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/businessprocesses-event/businessprocesses-event-listener/pom.xml
+++ b/businessprocesses-event/businessprocesses-event-listener/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>businessprocesses-event</artifactId>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
-        <version>25.104.1-M2-SNAPSHOT</version>
+        <version>25.104.0-M3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/businessprocesses-event/businessprocesses-event-processor/pom.xml
+++ b/businessprocesses-event/businessprocesses-event-processor/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>businessprocesses-event</artifactId>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
-        <version>25.104.1-M2-SNAPSHOT</version>
+        <version>25.104.0-M3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/businessprocesses-event/pom.xml
+++ b/businessprocesses-event/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>businessprocesses-parent</artifactId>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
-        <version>25.104.1-M2-SNAPSHOT</version>
+        <version>25.104.0-M3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/businessprocesses-healthchecks/pom.xml
+++ b/businessprocesses-healthchecks/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>businessprocesses-parent</artifactId>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
-        <version>25.104.1-M2-SNAPSHOT</version>
+        <version>25.104.0-M3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/businessprocesses-integration-test/pom.xml
+++ b/businessprocesses-integration-test/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
         <artifactId>businessprocesses-parent</artifactId>
-        <version>25.104.1-M2-SNAPSHOT</version>
+        <version>25.104.0-M3-SNAPSHOT</version>
     </parent>
 
     <artifactId>businessprocesses-integration-test</artifactId>

--- a/businessprocesses-query/businessprocesses-query-api/pom.xml
+++ b/businessprocesses-query/businessprocesses-query-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
         <artifactId>businessprocesses-query</artifactId>
-        <version>25.104.1-M2-SNAPSHOT</version>
+        <version>25.104.0-M3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>war</packaging>

--- a/businessprocesses-query/businessprocesses-query-view/pom.xml
+++ b/businessprocesses-query/businessprocesses-query-view/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
         <artifactId>businessprocesses-query</artifactId>
-        <version>25.104.1-M2-SNAPSHOT</version>
+        <version>25.104.0-M3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/businessprocesses-query/pom.xml
+++ b/businessprocesses-query/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
         <artifactId>businessprocesses-parent</artifactId>
-        <version>25.104.1-M2-SNAPSHOT</version>
+        <version>25.104.0-M3-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/businessprocesses-service/pom.xml
+++ b/businessprocesses-service/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>businessprocesses-parent</artifactId>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
-        <version>25.104.1-M2-SNAPSHOT</version>
+        <version>25.104.0-M3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/businessprocesses-viewstore/businessprocesses-viewstore-liquibase/pom.xml
+++ b/businessprocesses-viewstore/businessprocesses-viewstore-liquibase/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
         <artifactId>businessprocesses-viewstore</artifactId>
-        <version>25.104.1-M2-SNAPSHOT</version>
+        <version>25.104.0-M3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/businessprocesses-viewstore/businessprocesses-viewstore-persistence/pom.xml
+++ b/businessprocesses-viewstore/businessprocesses-viewstore-persistence/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>businessprocesses-viewstore</artifactId>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
-        <version>25.104.1-M2-SNAPSHOT</version>
+        <version>25.104.0-M3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/businessprocesses-viewstore/pom.xml
+++ b/businessprocesses-viewstore/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>businessprocesses-parent</artifactId>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
-        <version>25.104.1-M2-SNAPSHOT</version>
+        <version>25.104.0-M3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>uk.gov.moj.cpp.common</groupId>
         <artifactId>service-parent-pom</artifactId>
-        <version>25.104.0-M4</version>
+        <version>25.104.0-M7</version>
     </parent>
 
     <groupId>uk.gov.moj.cpp.bpm</groupId>
     <artifactId>businessprocesses-parent</artifactId>
-    <version>25.104.1-M2-SNAPSHOT</version>
+    <version>25.104.0-M3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -36,11 +36,11 @@
         <cpp.camunda.version>7.24.0</cpp.camunda.version>
 
         <!-- corresponding context versions -->
-        <coredomain.version>25.104.0-M4</coredomain.version>
+        <coredomain.version>25.104.0-M7</coredomain.version>
         <sjp.version>17.104.180</sjp.version>
-        <hearing.version>17.104.173</hearing.version>
+        <hearing.version>17.104.179</hearing.version>
         <referencedata.version>17.103.133</referencedata.version>
-        <progression.version>17.0.269</progression.version>
+        <progression.version>17.0.279</progression.version>
         <usersgroups.version>17.104.50</usersgroups.version>
         <listing.version>17.103.175</listing.version>
         <h2.version>2.3.232</h2.version>


### PR DESCRIPTION
Bumps businessprocesses (Camunda) onto the latest released framework service-parent-pom.

## Changes
- `service-parent-pom` `25.104.0-M4` -> **`25.104.0-M7`** (pulls platform-libraries M8 + core-domain M7 transitively)
- `coredomain.version` `25.104.0-M4` -> **`25.104.0-M7`**
- project version `25.104.1-M2-SNAPSHOT` -> **`25.104.0-M3-SNAPSHOT`** (M2 already released; third digit always 0, milestone = latest-released + 1)
- refresh stale MoJ interface versions required by `enforce-moj-latest-interfaces`:
  - `hearing.version` 17.104.173 -> **17.104.179**
  - `progression.version` 17.0.269 -> **17.0.279**

No functional code changes — framework/version bump plus mandatory interface-version refresh.

## Verification
`rit` (full integration-test run) **GREEN** on WildFly 40 / JDK 25 / Camunda 7.24:
- RESULT: 1/1 war came back with pong
- 0 rollbacks
- unit suites pass; integration-test module 48 run, 0 failures, 0 errors (2 expected skips)
- BUILD SUCCESS