### PR TITLE
Bump progression interface pin to 17.0.286 (latest-interfaces enforcer)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <sjp.version>17.104.192</sjp.version>
         <hearing.version>17.104.183</hearing.version>
         <referencedata.version>17.104.138</referencedata.version>
-        <progression.version>17.0.283</progression.version>
+        <progression.version>17.0.286</progression.version>
         <usersgroups.version>17.104.50</usersgroups.version>
         <listing.version>17.104.8</listing.version>
         <h2.version>2.3.232</h2.version>


### PR DESCRIPTION
The post-merge validation build on `team/25.104.x` fails the `enforce-moj-latest-interfaces` rule: `progression` released **17.0.286** after PR #70's pins were set (17.0.283). Brings `progression.version` current. Full build green with `-U` (no enforcer skip); progression 17.0.286's schema change (`correct-hearing-days-without-court-centre` removed) does not affect businessprocesses compilation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)