### PR TITLE
Bump milestone version to 25.104.3-M4-SNAPSHOT (re-trigger release + docker image)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ buildContexts.sh
 
 lightning-jenkins.properties
 **/.DS_Store
+
+# Maven Shade plugin generated artifact
+dependency-reduced-pom.xml

--- a/businessprocesses-command/businessprocesses-command-handler/pom.xml
+++ b/businessprocesses-command/businessprocesses-command-handler/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>businessprocesses-command</artifactId>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
-        <version>25.104.3-M3-SNAPSHOT</version>
+        <version>25.104.3-M4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/businessprocesses-command/pom.xml
+++ b/businessprocesses-command/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
         <artifactId>businessprocesses-parent</artifactId>
-        <version>25.104.3-M3-SNAPSHOT</version>
+        <version>25.104.3-M4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/businessprocesses-domain/businessprocesses-domain-aggregate/pom.xml
+++ b/businessprocesses-domain/businessprocesses-domain-aggregate/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>businessprocesses-domain</artifactId>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
-        <version>25.104.3-M3-SNAPSHOT</version>
+        <version>25.104.3-M4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/businessprocesses-domain/businessprocesses-domain-events/pom.xml
+++ b/businessprocesses-domain/businessprocesses-domain-events/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>businessprocesses-domain</artifactId>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
-        <version>25.104.3-M3-SNAPSHOT</version>
+        <version>25.104.3-M4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/businessprocesses-domain/pom.xml
+++ b/businessprocesses-domain/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>businessprocesses-parent</artifactId>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
-        <version>25.104.3-M3-SNAPSHOT</version>
+        <version>25.104.3-M4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/businessprocesses-event-sources/pom.xml
+++ b/businessprocesses-event-sources/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>businessprocesses-parent</artifactId>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
-        <version>25.104.3-M3-SNAPSHOT</version>
+        <version>25.104.3-M4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/businessprocesses-event/businessprocesses-event-domain/pom.xml
+++ b/businessprocesses-event/businessprocesses-event-domain/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>businessprocesses-event</artifactId>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
-        <version>25.104.3-M3-SNAPSHOT</version>
+        <version>25.104.3-M4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/businessprocesses-event/businessprocesses-event-listener/pom.xml
+++ b/businessprocesses-event/businessprocesses-event-listener/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>businessprocesses-event</artifactId>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
-        <version>25.104.3-M3-SNAPSHOT</version>
+        <version>25.104.3-M4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/businessprocesses-event/businessprocesses-event-processor/pom.xml
+++ b/businessprocesses-event/businessprocesses-event-processor/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>businessprocesses-event</artifactId>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
-        <version>25.104.3-M3-SNAPSHOT</version>
+        <version>25.104.3-M4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/businessprocesses-event/pom.xml
+++ b/businessprocesses-event/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>businessprocesses-parent</artifactId>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
-        <version>25.104.3-M3-SNAPSHOT</version>
+        <version>25.104.3-M4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/businessprocesses-healthchecks/pom.xml
+++ b/businessprocesses-healthchecks/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>businessprocesses-parent</artifactId>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
-        <version>25.104.3-M3-SNAPSHOT</version>
+        <version>25.104.3-M4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/businessprocesses-integration-test/pom.xml
+++ b/businessprocesses-integration-test/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
         <artifactId>businessprocesses-parent</artifactId>
-        <version>25.104.3-M3-SNAPSHOT</version>
+        <version>25.104.3-M4-SNAPSHOT</version>
     </parent>
 
     <artifactId>businessprocesses-integration-test</artifactId>

--- a/businessprocesses-query/businessprocesses-query-api/pom.xml
+++ b/businessprocesses-query/businessprocesses-query-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
         <artifactId>businessprocesses-query</artifactId>
-        <version>25.104.3-M3-SNAPSHOT</version>
+        <version>25.104.3-M4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>war</packaging>

--- a/businessprocesses-query/businessprocesses-query-view/pom.xml
+++ b/businessprocesses-query/businessprocesses-query-view/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
         <artifactId>businessprocesses-query</artifactId>
-        <version>25.104.3-M3-SNAPSHOT</version>
+        <version>25.104.3-M4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/businessprocesses-query/pom.xml
+++ b/businessprocesses-query/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
         <artifactId>businessprocesses-parent</artifactId>
-        <version>25.104.3-M3-SNAPSHOT</version>
+        <version>25.104.3-M4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/businessprocesses-service/pom.xml
+++ b/businessprocesses-service/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>businessprocesses-parent</artifactId>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
-        <version>25.104.3-M3-SNAPSHOT</version>
+        <version>25.104.3-M4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/businessprocesses-viewstore/businessprocesses-viewstore-liquibase/pom.xml
+++ b/businessprocesses-viewstore/businessprocesses-viewstore-liquibase/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
         <artifactId>businessprocesses-viewstore</artifactId>
-        <version>25.104.3-M3-SNAPSHOT</version>
+        <version>25.104.3-M4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/businessprocesses-viewstore/businessprocesses-viewstore-persistence/pom.xml
+++ b/businessprocesses-viewstore/businessprocesses-viewstore-persistence/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>businessprocesses-viewstore</artifactId>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
-        <version>25.104.3-M3-SNAPSHOT</version>
+        <version>25.104.3-M4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/businessprocesses-viewstore/pom.xml
+++ b/businessprocesses-viewstore/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>businessprocesses-parent</artifactId>
         <groupId>uk.gov.moj.cpp.bpm</groupId>
-        <version>25.104.3-M3-SNAPSHOT</version>
+        <version>25.104.3-M4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>uk.gov.moj.cpp.bpm</groupId>
     <artifactId>businessprocesses-parent</artifactId>
-    <version>25.104.3-M3-SNAPSHOT</version>
+    <version>25.104.3-M4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
Bumps the project milestone version one step (`-M3` → `-M4`) across all modules to produce a real diff. The ADO release pipeline gates the artifact rebuild + ACR docker-image build on `shouldRebuildArtifacts`, which an empty commit does not set — so the empty re-trigger did not build the image. This milestone bump forces `shouldRebuildArtifacts` and the docker-image build. Full build green with `-U` (no enforcer skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)